### PR TITLE
Add CI workflow for Bun tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - uses: oven-sh/setup-bun@v1
+      - run: bun install
+      - run: bun run check:icons
+      - run: bun run build:svgs


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `check:icons` and `build:svgs`
- remove stray `package-lock.json`

## Testing
- `bun run check:icons`
- `bun run build:svgs`


------
https://chatgpt.com/codex/tasks/task_e_684120edc8008324bdb6b9aaed66ef24