### PR TITLE
Add lint step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,6 @@ jobs:
           node-version: 20
       - uses: oven-sh/setup-bun@v1
       - run: bun install
+      - run: bun run lint
       - run: bun run check:icons
       - run: bun run build:svgs


### PR DESCRIPTION
## Summary
- run lint during GitHub Actions workflow

## Testing
- `bun run lint` *(fails: `no-unused-vars` in createReactSolidComponent.js)*

------
https://chatgpt.com/codex/tasks/task_e_68412ee146408324813accbaff815ef9