### PR TITLE
Add env var checks for service scripts

### DIFF
--- a/scripts/serve-tags-playground.mjs
+++ b/scripts/serve-tags-playground.mjs
@@ -15,6 +15,15 @@ const PLAYGROUND_FILE = path.join(__dirname, "../tags-playground.html");
 const PORT = 3001;
 const GEMINI_KEY = process.env.GEMINI_KEY;
 
+if (!GEMINI_KEY) {
+  console.error(
+    picocolors.red(
+      "GEMINI_KEY environment variable is required to run the playground server",
+    ),
+  );
+  process.exit(1);
+}
+
 const server = http.createServer(async (req, res) => {
   const parsedUrl = url.parse(req.url, true);
 

--- a/scripts/upload-algolia.mjs
+++ b/scripts/upload-algolia.mjs
@@ -5,13 +5,24 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import picocolors from "picocolors";
 import { algoliasearch } from "algoliasearch";
+import "dotenv/config";
 
 console.log(picocolors.blue("Starting Algolia upload process..."));
 
+const { ALGOLIA_APPLICATION_ID, ALGOLIA_ADMIN_API_KEY } = process.env;
+if (!ALGOLIA_APPLICATION_ID || !ALGOLIA_ADMIN_API_KEY) {
+  console.error(
+    picocolors.red(
+      "ALGOLIA_APPLICATION_ID and ALGOLIA_ADMIN_API_KEY must be set in the environment",
+    ),
+  );
+  process.exit(1);
+}
+
 // Connect and authenticate with your Algolia app
 const client = algoliasearch(
-  process.env.ALGOLIA_APPLICATION_ID,
-  process.env.ALGOLIA_ADMIN_API_KEY
+  ALGOLIA_APPLICATION_ID,
+  ALGOLIA_ADMIN_API_KEY,
 );
 console.log(picocolors.green("Connected to Algolia"));
 


### PR DESCRIPTION
## Summary
- ensure Algolia and Gemini scripts fail fast when env vars are missing

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6842bcd91664832494e3fbf533f059ae