### PR TITLE
Add build-all script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,14 @@
     "check:icons": "bun ./scripts/check-icons.mjs",
     "cleanup": "rm -rf ./packages/icons/react ./packages/icons-react/dist ./packages/icons-react/src/icons.js ./packages/icons-react/src/icons/*.js ./packages/icons-react/src/icons-solid/*.js ./regular-icon-temp",
     "copy:icons": "rm -rf ./packages/icons/icons && mkdir ./packages/icons/icons && cp -r ./icons/*.svg ./packages/icons/icons && rm -rf ./packages/icons/icons-solid && mkdir ./packages/icons/icons-solid && cp -r ./icons-solid/*.svg ./packages/icons/icons-solid",
-    "everything-everywhere-all-at-once": "bun run check:icons && bun run build:svgs && bun run build:tags && bun run oslllo-svg-fixer && bun run build:svgtofont-regular && bun run build:svgtofont-solid && bun run copy:icons && bun run cleanup && bun run build:meta && bun run build:react && bun run build:playground && bun run upload-algolia",
+    "everything-everywhere-all-at-once": "bun run build-all",
     "oslllo-svg-fixer": "mkdir -p ./regular-icon-temp && oslllo-svg-fixer -s ./icons -d ./regular-icon-temp --sp",
     "publish": "bunx lerna publish --no-private --create-release=github --conventional-commits",
     "upload-algolia": "bun ./scripts/upload-algolia.mjs",
     "manage-tags": "bun ./scripts/build-tags-playground.mjs && bun ./scripts/serve-tags-playground.mjs",
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "build-all": "bun ./scripts/build-all.mjs"
   },
   "devDependencies": {
     "@atomico/rollup-plugin-sizes": "^1.1.4",

--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import picocolors from 'picocolors';
+
+const tasks = [
+  'check:icons',
+  'build:svgs',
+  'build:tags',
+  'oslllo-svg-fixer',
+  'build:svgtofont-regular',
+  'build:svgtofont-solid',
+  'copy:icons',
+  'cleanup',
+  'build:meta',
+  'build:react',
+  'build:playground',
+  'upload-algolia',
+];
+
+const scriptName = path.basename(fileURLToPath(import.meta.url));
+const timeLabel = picocolors.cyan(`[${scriptName}] finished`);
+
+async function runTask(name) {
+  console.log(picocolors.blue(`\n> ${name}`));
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('bun', ['run', name], { stdio: 'inherit' });
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Task '${name}' failed with exit code ${code}`));
+      }
+    });
+  });
+}
+
+(async () => {
+  console.log(picocolors.cyan(`[${scriptName}] started`));
+  console.time(timeLabel);
+
+  try {
+    for (const task of tasks) {
+      await runTask(task);
+    }
+    console.timeEnd(timeLabel);
+    console.log(picocolors.green('All tasks completed successfully.'));
+  } catch (error) {
+    console.timeEnd(timeLabel);
+    console.error(picocolors.red(error.message));
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add `build-all.mjs` script to run build tasks
- hook `everything-everywhere-all-at-once` script to use `bun run build-all`
- expose script as `build-all` in `package.json`

## Testing
- `bun run lint`
- `bun x prettier --write package.json scripts/build-all.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6842bcbb0b648324a0b612f52657d997