### PR TITLE
Add Vue 3 icon package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@ packages/icons*/src/icons/*
 packages/icons*/src/icons-solid/*
 packages/icons*/stats/*
 packages/icons*/dist
+packages/icons-vue/src/icons.js
+packages/icons-vue/src/icons-solid.js
 tags-playground.html
 tags_latest.json

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:meta": "bun ./scripts/build-meta.mjs",
     "build:playground": "bun ./scripts/build-playground.mjs",
     "build:react": "bun ./scripts/build-react.mjs && rollup -c ./scripts/rollup.config.mjs",
+    "build:vue": "bun ./scripts/build-vue.mjs && rollup -c ./scripts/rollup.config.vue.mjs",
     "build:svgs": "bun ./scripts/build-svgs.mjs",
     "build:svgtofont-regular": "svgtofont --sources ./regular-icon-temp --output ./packages/icons --fontName mynaui",
     "build:svgtofont-solid": "svgtofont --sources ./icons-solid --output ./packages/icons --fontName mynaui-solid",

--- a/packages/icons-vue/LICENSE
+++ b/packages/icons-vue/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Praveen Juge
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/icons-vue/README.md
+++ b/packages/icons-vue/README.md
@@ -1,0 +1,47 @@
+# MynaUI Icons Vue
+
+Beautifully crafted open source icons from Myna UI.
+
+## Install
+
+```sh
+npm i @mynaui/icons-vue
+```
+
+or
+
+```sh
+bun i @mynaui/icons-vue
+```
+
+or
+
+```sh
+yarn add @mynaui/icons-vue
+```
+
+or download the package from [here](https://github.com/praveenjuge/mynaui-icons/releases).
+
+## Usage
+
+```vue
+<script setup>
+import { Heart } from "@mynaui/icons-vue";
+</script>
+
+<template>
+  <Heart color="green" />
+</template>
+```
+
+### Props
+
+| name     | type             | default      |
+| -------- | ---------------- | ------------ |
+| `size`   | Number \| String | 24           |
+| `stroke` | Number \| String | 1.5          |
+| `color`  | String           | currentColor |
+
+## License
+
+[MIT License](https://github.com/praveenjuge/mynaui-icons/blob/master/LICENSE).

--- a/packages/icons-vue/package.json
+++ b/packages/icons-vue/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@mynaui/icons-vue",
+  "version": "0.3.8",
+  "description": "1180+ beautifully crafted open source icons for your next project.",
+  "keywords": [
+    "icons",
+    "svg",
+    "vue",
+    "mynaui",
+    "icon-library",
+    "icon-pack",
+    "icon-set",
+    "icons-vue"
+  ],
+  "homepage": "https://mynaui.com/icons",
+  "bugs": {
+    "url": "https://github.com/praveenjuge/mynaui-icons/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/praveenjuge/mynaui-icons.git"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/praveenjuge"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Praveen Juge",
+    "url": "https://praveenjuge.com/"
+  },
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/myna-icons-vue.d.ts",
+      "import": "./dist/esm/myna-icons-vue.js",
+      "require": "./dist/cjs/myna-icons-vue.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/cjs/myna-icons-vue.js",
+  "unpkg": "dist/umd/myna-icons-vue.min.js",
+  "module": "dist/esm/myna-icons-vue.js",
+  "types": "dist/myna-icons-vue.d.ts",
+  "typings": "dist/myna-icons-vue.d.ts",
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md",
+    "package.json",
+    "!.DS_Store"
+  ],
+  "peerDependencies": {
+    "vue": "^3.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": ""
+}

--- a/packages/icons-vue/src/createVueComponent.js
+++ b/packages/icons-vue/src/createVueComponent.js
@@ -1,0 +1,34 @@
+import { defineComponent, h } from 'vue';
+
+export default (iconName, iconNamePascal, iconNode) => {
+  return defineComponent({
+    name: iconNamePascal,
+    props: {
+      color: { type: String, default: 'currentColor' },
+      size: { type: [String, Number], default: 24 },
+      stroke: { type: [String, Number], default: '1.5' },
+    },
+    setup(props, { slots, attrs }) {
+      return () =>
+        h(
+          'svg',
+          {
+            ...attrs,
+            width: props.size,
+            height: props.size,
+            fill: 'none',
+            stroke: props.color,
+            strokeWidth: props.stroke,
+            viewBox: '0 0 24 24',
+            strokeLinecap: 'round',
+            strokeLinejoin: 'round',
+            xmlns: 'http://www.w3.org/2000/svg',
+          },
+          [
+            ...iconNode.map(([tag, attrs]) => h(tag, attrs)),
+            ...(slots.default ? slots.default() : []),
+          ],
+        );
+    },
+  });
+};

--- a/packages/icons-vue/src/createVueSolidComponent.js
+++ b/packages/icons-vue/src/createVueSolidComponent.js
@@ -1,0 +1,29 @@
+import { defineComponent, h } from 'vue';
+
+export default (iconName, iconNamePascal, iconNode) => {
+  return defineComponent({
+    name: iconNamePascal,
+    props: {
+      color: { type: String, default: 'currentColor' },
+      size: { type: [String, Number], default: 24 },
+    },
+    setup(props, { slots, attrs }) {
+      return () =>
+        h(
+          'svg',
+          {
+            ...attrs,
+            width: props.size,
+            height: props.size,
+            fill: props.color,
+            viewBox: '0 0 24 24',
+            xmlns: 'http://www.w3.org/2000/svg',
+          },
+          [
+            ...iconNode.map(([tag, attrs]) => h(tag, attrs)),
+            ...(slots.default ? slots.default() : []),
+          ],
+        );
+    },
+  });
+};

--- a/packages/icons-vue/src/myna-icons-vue.js
+++ b/packages/icons-vue/src/myna-icons-vue.js
@@ -1,0 +1,4 @@
+export * from "./icons";
+export * from "./icons-solid";
+export { default as createVueComponent } from "./createVueComponent";
+export { default as createVueSolidComponent } from "./createVueSolidComponent";

--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -16,6 +16,7 @@ const tasks = [
   'cleanup',
   'build:meta',
   'build:react',
+  'build:vue',
   'build:playground',
   'upload-algolia',
 ];

--- a/scripts/build-vue.mjs
+++ b/scripts/build-vue.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+import fs from "fs-extra";
+import path from "path";
+import { fileURLToPath } from "url";
+import { parseSync } from "svgson";
+import picocolors from "picocolors";
+
+const getCurrentDirPath = () => path.dirname(fileURLToPath(import.meta.url));
+const HOME_DIR = path.resolve(getCurrentDirPath(), "..");
+const ICONS_DIR = path.resolve(HOME_DIR, "icons");
+const ICONS_SOLID_DIR = path.resolve(HOME_DIR, "icons-solid");
+const PACKAGES_DIR = path.resolve(HOME_DIR, "packages");
+
+const readSvgDirectory = (directory) =>
+  fs.readdirSync(directory).filter((file) => path.extname(file) === ".svg");
+
+const readSvg = (fileName, directory) =>
+  fs.readFileSync(path.join(directory, fileName), "utf-8");
+
+const toCamelCase = (string) =>
+  string.replace(/^([A-Z])|[\s-_]+(\w)/g, (match, p1, p2) =>
+    p2 ? p2.toUpperCase() : p1.toLowerCase()
+  );
+
+const toPascalCase = (string) => {
+  const camelCase = toCamelCase(string);
+  return camelCase.charAt(0).toUpperCase() + camelCase.slice(1);
+};
+
+const readSvgs = (dir) => {
+  const svgFiles = readSvgDirectory(dir);
+  return svgFiles.map((svgFile) => {
+    const name = path.basename(svgFile, ".svg");
+    const namePascal = toPascalCase(name);
+    const contents = readSvg(svgFile, dir).trim();
+    const filePath = path.resolve(dir, svgFile);
+    const obj = parseSync(
+      contents.replace(
+        '<path stroke="none" d="M0 0h24v24H0z" fill="none"/>',
+        ""
+      )
+    );
+    return { name, namePascal, contents, obj, path: filePath };
+  });
+};
+
+// Define the buildIcons function
+const buildIcons = ({
+  name,
+  componentTemplate,
+  indexItemTemplate,
+  indexTypeTemplate,
+  extension = "js",
+  key = true,
+  pascalCase = false,
+  inputDir,
+  outputSubDir,
+  nameSuffix = '',
+}) => {
+  const DIST_DIR = path.resolve(PACKAGES_DIR, name);
+  const svgFiles = readSvgs(inputDir);
+
+  let index = [];
+  let typings = [];
+
+  svgFiles.forEach((svgFile, i) => {
+    const children = svgFile.obj.children
+      .filter(
+        ({ attributes }) =>
+          !attributes.d || attributes.d !== "M0 0h24v24H0z"
+      )
+      .map(({ name, attributes }, j) => {
+        if (key) attributes.key = `svg-${j}`;
+        if (pascalCase) {
+          attributes.strokeWidth = attributes["stroke-width"];
+          delete attributes["stroke-width"];
+        }
+        return [name, attributes];
+      });
+
+    const componentName = svgFile.namePascal + nameSuffix;
+
+    fs.ensureDirSync(path.resolve(DIST_DIR, `src/${outputSubDir}`));
+
+    fs.writeFileSync(
+      path.resolve(
+        DIST_DIR,
+        `src/${outputSubDir}`,
+        `${componentName}.${extension}`
+      ),
+      componentTemplate({
+        name: svgFile.name,
+        namePascal: componentName,
+        children,
+      }),
+      "utf-8"
+    );
+
+    console.log(
+      picocolors.green(
+        `Building ${componentName} (${i + 1}/${svgFiles.length})\r`
+      )
+    );
+
+    index.push(
+      indexItemTemplate({
+        name: svgFile.name,
+        namePascal: componentName,
+        outputSubDir,
+      })
+    );
+
+    typings.push(
+      indexTypeTemplate({
+        name: svgFile.name,
+        namePascal: componentName,
+      })
+    );
+  });
+
+  fs.writeFileSync(
+    path.resolve(DIST_DIR, `./src/${outputSubDir}.js`),
+    index.join("\n"),
+    "utf-8"
+  );
+
+  // Return the typings instead of writing them here
+  return { typings };
+};
+
+// Define templates for regular icons
+const componentTemplate = ({ name, namePascal, children }) => `\
+import createVueComponent from '../createVueComponent';
+export default createVueComponent('${name}', '${namePascal}', ${JSON.stringify(
+  children
+)});`;
+
+const indexItemTemplate = ({ name, namePascal, outputSubDir }) =>
+  `export { default as ${namePascal} } from './${outputSubDir}/${namePascal}';`;
+
+const typeDefinitionsTemplate = () => `import type { DefineComponent } from 'vue';
+
+export interface MynaIconsProps {
+    size?: string | number;
+    stroke?: string | number;
+}
+
+export declare const createVueComponent: (iconName: string, iconNamePascal: string, iconNode: any[]) => DefineComponent<MynaIconsProps>;
+
+export type Icon = DefineComponent<MynaIconsProps>;
+
+// Generated icons`;
+
+const indexTypeTemplate = ({ namePascal }) =>
+  `export declare const ${namePascal}: (props: MynaIconsProps) => JSX.Element;`;
+
+// Define templates for solid icons
+const solidComponentTemplate = ({ name, namePascal, children }) => `\
+import createVueSolidComponent from '../createVueSolidComponent';
+export default createVueSolidComponent('${name}', '${namePascal}', ${JSON.stringify(
+  children
+)});`;
+
+// Build normal icons
+const normalIconsResult = buildIcons({
+  name: "icons-vue",
+  componentTemplate,
+  indexItemTemplate,
+  indexTypeTemplate,
+  pascalCase: true,
+  inputDir: ICONS_DIR,
+  outputSubDir: "icons",
+});
+
+// Build solid icons
+const solidIconsResult = buildIcons({
+  name: "icons-vue",
+  componentTemplate: solidComponentTemplate,
+  indexItemTemplate,
+  indexTypeTemplate,
+  pascalCase: true,
+  inputDir: ICONS_SOLID_DIR,
+  outputSubDir: "icons-solid",
+  nameSuffix: "Solid",
+});
+
+// Combine typings from both builds
+const allTypings = normalIconsResult.typings.concat(solidIconsResult.typings);
+
+// Write combined type definitions file
+const DIST_DIR = path.resolve(PACKAGES_DIR, "icons-vue");
+
+fs.ensureDirSync(path.resolve(DIST_DIR, "./dist/"));
+
+fs.writeFileSync(
+  path.resolve(DIST_DIR, `./dist/myna-icons-vue.d.ts`),
+  typeDefinitionsTemplate() + "\n" + allTypings.join("\n"),
+  "utf-8"
+);

--- a/scripts/build-vue.mjs
+++ b/scripts/build-vue.mjs
@@ -153,7 +153,7 @@ export type Icon = DefineComponent<MynaIconsProps>;
 // Generated icons`;
 
 const indexTypeTemplate = ({ namePascal }) =>
-  `export declare const ${namePascal}: (props: MynaIconsProps) => JSX.Element;`;
+  `export declare const ${namePascal}: DefineComponent<MynaIconsProps>;`;
 
 // Define templates for solid icons
 const solidComponentTemplate = ({ name, namePascal, children }) => `\

--- a/scripts/rollup.config.vue.mjs
+++ b/scripts/rollup.config.vue.mjs
@@ -1,0 +1,78 @@
+import fs from "fs";
+import esbuild from "rollup-plugin-esbuild";
+import license from "rollup-plugin-license";
+import bundleSize from "@atomico/rollup-plugin-sizes";
+
+const getRollupPlugins = (pkg, minify) => [
+  esbuild({ minify }),
+  license({ banner: `${pkg.name} v${pkg.version} - ${pkg.license}` }),
+  bundleSize(),
+];
+
+const pkg = JSON.parse(
+  fs.readFileSync("./packages/icons-vue/package.json", "utf-8")
+);
+
+const packageName = "@myna/icons-vue";
+const outputFileName = "myna-icons-vue";
+const outputDir = "./packages/icons-vue/dist";
+const inputs = ["./packages/icons-vue/src/myna-icons-vue.js"];
+const bundles = [
+  {
+    format: "umd",
+    inputs,
+    outputDir,
+    minify: true,
+  },
+  {
+    format: "umd",
+    inputs,
+    outputDir,
+  },
+  {
+    format: "cjs",
+    inputs,
+    outputDir,
+  },
+  {
+    format: "es",
+    inputs,
+    outputDir,
+  },
+  {
+    format: "esm",
+    inputs,
+    outputDir,
+    preserveModules: true,
+  },
+];
+
+const configs = bundles
+  .map(({ inputs, outputDir, format, minify, preserveModules }) =>
+    inputs.map((input) => ({
+      input,
+      plugins: getRollupPlugins(pkg, minify),
+      external: ["vue"],
+      output: {
+        name: packageName,
+        ...(preserveModules
+          ? {
+              dir: `${outputDir}/${format}`,
+            }
+          : {
+              file: `${outputDir}/${format}/${outputFileName}${
+                minify ? ".min" : ""
+              }.js`,
+            }),
+        format,
+        sourcemap: true,
+        preserveModules,
+        globals: {
+          vue: "Vue",
+        },
+      },
+    }))
+  )
+  .flat();
+
+export default configs;

--- a/scripts/rollup.config.vue.mjs
+++ b/scripts/rollup.config.vue.mjs
@@ -13,7 +13,7 @@ const pkg = JSON.parse(
   fs.readFileSync("./packages/icons-vue/package.json", "utf-8")
 );
 
-const packageName = "@myna/icons-vue";
+const packageName = "@mynaui/icons-vue";
 const outputFileName = "myna-icons-vue";
 const outputDir = "./packages/icons-vue/dist";
 const inputs = ["./packages/icons-vue/src/myna-icons-vue.js"];


### PR DESCRIPTION
## Summary
- introduce `@mynaui/icons-vue` for Vue 3
- support Vue builds with new build-vue script and rollup config
- update build-all task and package.json scripts
- ignore generated Vue icon index files
- remove icons-vue `icons.js` and `icons-solid.js` from repo

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68448906b7a4832499f3ccc647e00a8d